### PR TITLE
Bugfix: First item added to visited_items is not a tuple

### DIFF
--- a/maze_transformer/generation/generators.py
+++ b/maze_transformer/generation/generators.py
@@ -60,7 +60,8 @@ class LatticeMazeGenerators:
         # print(f"{grid_shape = } {start_coord = }")
 
         # initialize the stack with the target coord
-        visited_cells: set[tuple[int, int]] = set(tuple(start_coord))
+        visited_cells: set[tuple[int, int]] = set()
+        visited_cells.add(tuple(start_coord))
         stack: list[Coord] = [start_coord]
 
         # loop until the stack is empty


### PR DESCRIPTION
I noticed a small issue where the first item being added to `visited_items` was not a tuple. I think this is because when you pass a tuple to the constructor of a set, it adds each item individually. 

I'm not sure if this was actually affecting the behaviour, but it seemed like it made it possible to visit the 1st cell twice. 

Evidence from debugger (note value of `visited_items`):
![Screenshot 2023-01-31 at 16 40 20](https://user-images.githubusercontent.com/26048292/215831911-dab2b8e0-bc5c-4d1f-8658-d17fec1e9a2f.png)


Updated screenshot after the fix is made:
![Screenshot 2023-01-31 at 16 46 50](https://user-images.githubusercontent.com/26048292/215831999-797e42c9-2b1c-4cd0-be81-af84cba86034.png)


Depends on #1 