### PR TITLE
Run plot_loss

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 attrs==22.2.0
+black==23.1.0
 certifi==2022.12.7
 charset-normalizer==3.0.1
+click==8.1.3
 contourpy==1.0.7
 cycler==0.11.0
 exceptiongroup==1.1.0
@@ -14,10 +16,13 @@ isort==5.12.0
 kiwisolver==1.4.4
 libcst==0.4.9
 matplotlib==3.6.3
+mypy==1.0.0
+mypy-extensions==1.0.0
 numpy==1.23.1
 packaging==23.0
 pathspec==0.10.3
 Pillow==9.4.0
+platformdirs==3.0.0
 pluggy==1.0.0
 pycln==2.1.3
 pyparsing==3.0.9

--- a/src/maze_transformer/evaluation/plot_loss.py
+++ b/src/maze_transformer/evaluation/plot_loss.py
@@ -1,20 +1,43 @@
+from typing import Iterable, Tuple
+
+import matplotlib.pyplot as plt  # type: ignore[import]
 import numpy as np
-import matplotlib.pyplot as plt
-from muutils.logger import gather_val, gather_stream, get_any_from_stream
+from muutils.logger.log_util import ( # type: ignore[import]
+    gather_stream,
+    gather_val,
+    get_any_from_stream,
+)
 
 
 def plot_loss(
     log_path: str,
-    convolve_windows: int | list[int] | str = (10, 50, 100),
+    window_sizes: int | Iterable[int] | str = (10, 50, 100),
     raw_loss: bool | str = False,
 ):
     """
-    Plot the loss of the model.
+    Plots the loss over the training iteration, by reading log data from the log file specified by `log_path`.
+    Optionally, the loss curve can be smoothed by computing a rolling average using the specified window size(s).
+    Also, the raw loss curve can be plotted along with the smoothed curve.
+
+    Parameters
+    ----------
+    log_path (str):
+        Path to the training log file. This should be a file in `jsonl` format, as output by `training.train`.
+    window_sizes (int or list[int] or str, optional):
+        Window size(s) for computing rolling average of loss. Default is (10, 50, 100).
+    raw_loss (bool or str, optional):
+        Whether to plot the raw loss curve along with the smoothed curve. If a string is provided, it will be used as the format string for the raw loss curve. Default is False.
+
+    Returns:
+    None
+
+    Raises:
+    - ValueError: If `window_sizes` is not an int, list of ints, or a comma-separated string of ints.
     """
     data_raw: list[tuple] = gather_val(
         file=log_path,
         stream="train",
-        keys=("iter", "n_sequences", "loss"),
+        keys=("n_sequences", "loss"),
     )
 
     data_config: list[dict] = gather_stream(
@@ -26,29 +49,28 @@ def plot_loss(
 
     print(data_raw[:20])
 
-    iteration, total_sequences, loss = zip(*data_raw)
+    total_sequences, loss = zip(*data_raw)
 
     # compute a rolling average
-    if isinstance(convolve_windows, int):
-        convolve_windows = [convolve_windows]
-    elif isinstance(convolve_windows, (list, tuple)):
+    if isinstance(window_sizes, int):
+        window_sizes = [window_sizes]
+    elif isinstance(window_sizes, (list, tuple)):
         pass
-    elif isinstance(convolve_windows, str):
-        convolve_windows = [int(x) for x in convolve_windows.split(",")]
+    elif isinstance(window_sizes, str):
+        window_sizes = [int(x) for x in window_sizes.split(",")]
     else:
-        raise ValueError(f"{convolve_windows = }")
+        raise ValueError(f"{window_sizes = }")
 
     loss_rolling_arr: list[np.ndarray] = [
-        np.convolve(loss, np.ones(cv * 2) / (cv * 2), mode="valid")
-        for cv in convolve_windows
+        rolling_average(loss, window) for window in window_sizes
     ]
 
     if raw_loss:
         raw_loss_fmt: str = raw_loss if isinstance(raw_loss, str) else ","
         plt.plot(total_sequences, loss, raw_loss_fmt, label="raw losses")
-    for cv, loss_rolling in zip(convolve_windows, loss_rolling_arr):
+    for cv, loss_rolling in zip(window_sizes, loss_rolling_arr):
         plt.plot(
-            total_sequences[cv : 1 - cv],
+            total_sequences[cv - 1 :],
             loss_rolling,
             "-",
             label=f"rolling avg $(\\pm {cv})$",
@@ -68,3 +90,12 @@ def plot_loss(
     plt.title(title)
     plt.legend()
     plt.show()
+
+
+def rolling_average(x: Tuple[float], window: int):
+    if window > len(x):
+        raise ValueError(
+            f"Window for rolling average {window} is greater than the number of datapoints {len(x)}"
+        )
+
+    return list(np.convolve(x, np.ones(window) / window, mode="valid"))

--- a/tests/maze_transformer/evaluation/test_rolling_average.py
+++ b/tests/maze_transformer/evaluation/test_rolling_average.py
@@ -1,0 +1,18 @@
+import pytest
+
+from maze_transformer.evaluation.plot_loss import rolling_average
+
+
+def test_rolling_average_smaller_window():
+    x = (0, 1, 2, 4, 8)
+    assert rolling_average(x, 2) == [0.5, 1.5, 3.0, 6]
+
+
+def test_rolling_average_same_size():
+    x = (1, 2, 3, 4, 5)
+    assert rolling_average(x, 5) == [3.0]
+
+
+def test_rolling_average_larger_window():
+    with pytest.raises(ValueError):
+        rolling_average((1, 2, 3), 5)


### PR DESCRIPTION
A few changes made during the process of getting plot_loss to run:

* Make mypy happy
* Add docstring
* Rename `convolve_windows` -> `window_sizes` and stop doubling it
* Extract and test rolling_average function

Please double check that the output seems sensible.

## Command:
```
python scripts/plot_loss.py data/maze/g4-n10/g4-n10_tiny-v1_2023-02-08-15-49-24/log.jsonl  --window_sizes="5, 10, 20"
```

## Output:
<img width="752" alt="image" src="https://user-images.githubusercontent.com/26048292/217885622-5a8ecd8a-b120-44f5-b341-04f1fd79fd83.png">
