### PR TITLE
Remove directory filter for tests in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -43,8 +43,5 @@ jobs:
           poetry lock --check
           poetry install
 
-      - name: Unit tests
-        run: make unit
-
-      - name: Integration tests
-        run: make integration
+      - name: Unit and integration tests
+        run: poetry run make test


### PR DESCRIPTION
Merge `poetry run make unit` and `poetry run make integration` into a single call to `poetry run make test` to get rid of filtering on test directory. This prevents us from having to worry about errors not being caught because we put tests in the wrong directory, but it does make CI a little less neat. 

Happy to leave this one if it doesn't seem worth it to people