### PR TITLE
Remove unk token

### DIFF
--- a/maze_transformer/tokenizer.py
+++ b/maze_transformer/tokenizer.py
@@ -81,8 +81,9 @@ class HuggingMazeTokenizer(PreTrainedTokenizer):
 
         # We are having to do evil things here
         vocab: dict[str, int] = {token: i for i, token in enumerate(token_arr)}
-        vocab[self.unk_token] = len(vocab)
-        self.vocab: dict[str, int] = vocab
+        if self.unk_token not in vocab:  # maze-dataset >=X.X.X includes <UNK> already
+            vocab[self.unk_token] = len(vocab)
+            self.vocab: dict[str, int] = vocab
 
         special_tokens = list(SPECIAL_TOKENS.values())
         normal_tokens = [x for x in token_arr if x not in special_tokens]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,11 @@ repository = "https://github.com/understanding-search/maze-transformer"
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"
 # dataset
-maze-dataset = "^0.4.5"
+maze-dataset = "^1.0.0"
 # transformers
-torch = ">=1.13.1"
+torch = "^1.13.1"
 transformer-lens = "1.14.0"
-transformers = ">=4.34" # Dependency in transformer-lens 1.14.0
+transformers = "^4.34" # Dependency in transformer-lens 1.14.0
 # utils
 muutils = "^0.5.5"
 zanj = "^0.2.0"


### PR DESCRIPTION
`maze-dataset` 1.0.0 adds the "<UNK>" token to the vocabulary when using `MazeTokenizer2`. Add compatibility for this in `HuggingMazeTokenizer`.